### PR TITLE
Setup apollo server #3: Use dataSources

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const { ApolloServer, gql } = require("apollo-server");
-const axios = require("axios").default;
 const { RESTDataSource } = require("apollo-datasource-rest");
 
 const typeDefs = gql`

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const { ApolloServer, gql } = require("apollo-server");
 const axios = require("axios").default;
+const { RESTDataSource } = require("apollo-datasource-rest");
 
 const typeDefs = gql`
   type User {
@@ -23,6 +24,26 @@ const typeDefs = gql`
     posts: [Post]
   }
 `;
+
+class jsonPlaceAPI extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = "https://jsonplaceholder.typicode.com/";
+  }
+
+  async getUsers() {
+    const data = await this.get("/users");
+    return data;
+  }
+  async getUser(id) {
+    const data = await this.get(`/users/${id}`);
+    return data;
+  }
+  async getPosts() {
+    const data = await this.get("/posts");
+    return data;
+  }
+}
 
 const resolvers = {
   Query: {

--- a/index.js
+++ b/index.js
@@ -78,7 +78,15 @@ const resolvers = {
   },
 };
 
-const server = new ApolloServer({ typeDefs, resolvers });
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  dataSources: () => {
+    return {
+      jsonPlaceAPI: new jsonPlaceAPI(),
+    };
+  },
+});
 
 server.listen().then(({ url }) => {
   console.log(`🚀  Server ready at ${url}`);

--- a/index.js
+++ b/index.js
@@ -47,32 +47,21 @@ class jsonPlaceAPI extends RESTDataSource {
 
 const resolvers = {
   Query: {
-    hello: (parent, args) => `Hello ${args.name}`,
-    users: async () => {
-      const response = await axios.get(
-        "https://jsonplaceholder.typicode.com/users"
-      );
-      return response.data;
+    hello: (_, args) => `Hello ${args.name}`,
+    users: async (_, __, { dataSources }) => {
+      return dataSources.jsonPlaceAPI.getUsers();
     },
-    user: async (parent, args) => {
-      let response = await axios.get(
-        `https://jsonplaceholder.typicode.com/users/${args.id}`
-      );
-      return response.data;
+    user: async (_, args, { dataSources }) => {
+      return dataSources.jsonPlaceAPI.getUser(args.id);
     },
-    posts: async () => {
-      const response = await axios.get(
-        "https://jsonplaceholder.typicode.com/posts"
-      );
-      return response.data;
+    posts: async (_, __, { dataSources }) => {
+      return dataSources.jsonPlaceAPI.getPosts();
     },
   },
   User: {
-    myPosts: async (parent) => {
-      const response = await axios.get(
-        "https://jsonplaceholder.typicode.com/posts"
-      );
-      const myPosts = response.data.filter((post) => post.userId == parent.id);
+    myPosts: async (parent, __, { dataSources }) => {
+      const posts = await dataSources.jsonPlaceAPI.getPosts();
+      const myPosts = posts.filter((post) => post.userId == parent.id);
       return myPosts;
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "apollo-datasource-rest": "^3.5.3",
         "apollo-server": "^3.7.0",
         "axios": "^0.27.2",
         "graphql": "^16.5.0"
@@ -354,6 +355,21 @@
       "dependencies": {
         "apollo-server-caching": "^3.3.0",
         "apollo-server-env": "^4.2.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/apollo-datasource-rest": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/apollo-datasource-rest/-/apollo-datasource-rest-3.5.3.tgz",
+      "integrity": "sha512-xKzXl5TA0YEPHmIZXyPfDGtl/bnOjeI4ieOn1xQPLtsrtDRBjt46cXpGwNlsS8v9F4g7bG9GTcgOeNPHSxGy6A==",
+      "dependencies": {
+        "apollo-datasource": "^3.3.1",
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.1",
+        "apollo-server-errors": "^3.3.1",
+        "http-cache-semantics": "^4.1.0"
       },
       "engines": {
         "node": ">=12.0"
@@ -1307,8 +1323,7 @@
     "node_modules/http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-      "dev": true
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -2815,6 +2830,18 @@
         "apollo-server-env": "^4.2.1"
       }
     },
+    "apollo-datasource-rest": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/apollo-datasource-rest/-/apollo-datasource-rest-3.5.3.tgz",
+      "integrity": "sha512-xKzXl5TA0YEPHmIZXyPfDGtl/bnOjeI4ieOn1xQPLtsrtDRBjt46cXpGwNlsS8v9F4g7bG9GTcgOeNPHSxGy6A==",
+      "requires": {
+        "apollo-datasource": "^3.3.1",
+        "apollo-server-caching": "^3.3.0",
+        "apollo-server-env": "^4.2.1",
+        "apollo-server-errors": "^3.3.1",
+        "http-cache-semantics": "^4.1.0"
+      }
+    },
     "apollo-reporting-protobuf": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.1.tgz",
@@ -3526,8 +3553,7 @@
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-      "dev": true
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "http-errors": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/taigakiyokawa/learn_graphql_server#readme",
   "dependencies": {
+    "apollo-datasource-rest": "^3.5.3",
     "apollo-server": "^3.7.0",
     "axios": "^0.27.2",
     "graphql": "^16.5.0"


### PR DESCRIPTION
- `npm install apollo-datasource-rest`
- Add class jsonPlaceAPI extends RESTDataSource
- Add datasources to ApolloServer
- Use dataSources on resolvers
- Remove axios
